### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_builds.yml
+++ b/.github/workflows/docker_builds.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Publish Releases to Docker
       # only on releases
-      uses: elgohr/Publish-Docker-Github-Action@2.14
+      uses: elgohr/Publish-Docker-Github-Action@v5
       if: contains(github.ref, 'refs/tags/') && !contains(${{ steps.get_version.outputs.VERSION }}, 'rc') %% !contains(${{ steps.get_version.outputs.VERSION }}, 'dev')
       with:
         name: pytorchlightning/pytorch_lightning
@@ -33,7 +33,7 @@ jobs:
         tags: "${{ steps.get_version.outputs.VERSION }}-py${{ matrix.python_version }}-torch${{ matrix.pytorch_version }},stable-py${{ matrix.python_version }}-torch${{ matrix.pytorch_version }}"
     - name: Publish Master
       # publish master
-      uses: elgohr/Publish-Docker-Github-Action@2.14
+      uses: elgohr/Publish-Docker-Github-Action@v5
       if: github.event_name == 'push'
       with:
         name: pytorchlightning/pytorch_lightning


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore